### PR TITLE
load the apm commands lazily - greatly reduce the loading time 

### DIFF
--- a/src/apm-cli.coffee
+++ b/src/apm-cli.coffee
@@ -26,35 +26,34 @@ setupTempDirectory = ->
 
 setupTempDirectory()
 
-# TODO make loading lazy
-ciClass = require './ci'
-cleanClass = require './clean'
-configClass = require './config'
-dedupClass  = require './dedupe'
-developClass  = require './develop'
-disableClass  = require './disable'
-docsClass  = require './docs'
-enableClass  = require './enable'
-featuredClass  = require './featured'
-initClass  = require './init'
-installClass  = require './install'
-linksClass  = require './links'
-linkClass  = require './link'
-listClass  = require './list'
-loginClass  = require './login'
-publishClass  = require './publish'
-rebuildClass  = require './rebuild'
-rebuildModuleCacheClass  = require './rebuild-module-cache'
-searchClass  = require './search'
-starClass  = require './star'
-starsClass  = require './stars'
-testClass  = require './test'
-uninstallClass  = require './uninstall'
-unlinkClass  = require './unlink'
-unpublishClass  = require './unpublish'
-unstarClass  = require './unstar'
-upgradeClass  = require './upgrade'
-viewClass  = require './view'
+ciClass = -> require './ci'
+cleanClass = -> require './clean'
+configClass = -> require './config'
+dedupClass  = -> require './dedupe'
+developClass  = -> require './develop'
+disableClass  = -> require './disable'
+docsClass  = -> require './docs'
+enableClass  = -> require './enable'
+featuredClass  = -> require './featured'
+initClass  = -> require './init'
+installClass  = -> require './install'
+linksClass  = -> require './links'
+linkClass  = -> require './link'
+listClass  = -> require './list'
+loginClass  = -> require './login'
+publishClass  = -> require './publish'
+rebuildClass  = -> require './rebuild'
+rebuildModuleCacheClass  = -> require './rebuild-module-cache'
+searchClass  = -> require './search'
+starClass  = -> require './star'
+starsClass  = -> require './stars'
+testClass  = -> require './test'
+uninstallClass  = -> require './uninstall'
+unlinkClass  = -> require './unlink'
+unpublishClass  = -> require './unpublish'
+unstarClass  = -> require './unstar'
+upgradeClass  = -> require './upgrade'
+viewClass  = -> require './view'
 
 commands = {
   'ci': ciClass,
@@ -241,19 +240,19 @@ module.exports =
     if args.version
       printVersions(args, options.callback)
     else if args.help
-      if Command = commands[options.command]
+      if Command = commands[options.command]?()
         showHelp(new Command().parseOptions?(options.command))
       else
         showHelp(options)
       options.callback()
     else if command
       if command is 'help'
-        if Command = commands[options.commandArgs]
+        if Command = commands[options.commandArgs]?()
           showHelp(new Command().parseOptions?(options.commandArgs))
         else
           showHelp(options)
         options.callback()
-      else if Command = commands[command]
+      else if Command = commands[command]?()
         new Command().run(options)
       else
         options.callback("Unrecognized command: #{command}")

--- a/src/apm-cli.coffee
+++ b/src/apm-cli.coffee
@@ -26,41 +26,84 @@ setupTempDirectory = ->
 
 setupTempDirectory()
 
-commandClasses = [
-  require './ci'
-  require './clean'
-  require './config'
-  require './dedupe'
-  require './develop'
-  require './disable'
-  require './docs'
-  require './enable'
-  require './featured'
-  require './init'
-  require './install'
-  require './links'
-  require './link'
-  require './list'
-  require './login'
-  require './publish'
-  require './rebuild'
-  require './rebuild-module-cache'
-  require './search'
-  require './star'
-  require './stars'
-  require './test'
-  require './uninstall'
-  require './unlink'
-  require './unpublish'
-  require './unstar'
-  require './upgrade'
-  require './view'
-]
+# TODO make loading lazy
+ciClass = require './ci'
+cleanClass = require './clean'
+configClass = require './config'
+dedupClass  = require './dedupe'
+developClass  = require './develop'
+disableClass  = require './disable'
+docsClass  = require './docs'
+enableClass  = require './enable'
+featuredClass  = require './featured'
+initClass  = require './init'
+installClass  = require './install'
+linksClass  = require './links'
+linkClass  = require './link'
+listClass  = require './list'
+loginClass  = require './login'
+publishClass  = require './publish'
+rebuildClass  = require './rebuild'
+rebuildModuleCacheClass  = require './rebuild-module-cache'
+searchClass  = require './search'
+starClass  = require './star'
+starsClass  = require './stars'
+testClass  = require './test'
+uninstallClass  = require './uninstall'
+unlinkClass  = require './unlink'
+unpublishClass  = require './unpublish'
+unstarClass  = require './unstar'
+upgradeClass  = require './upgrade'
+viewClass  = require './view'
 
-commands = {}
-for commandClass in commandClasses
-  for name in commandClass.commandNames ? []
-    commands[name] = commandClass
+commands = {
+  'ci': ciClass,
+  'clean': cleanClass,
+  'prune': cleanClass,
+  'config': configClass,
+  'dedupe': dedupClass,
+  'dev': developClass,
+  'develop': developClass,
+  'disable': disableClass,
+  'docs': docsClass,
+  'home': docsClass,
+  'open': docsClass,
+  'enable': enableClass
+  'featured': featuredClass
+  'init': initClass,
+  'install': installClass,
+  'i': installClass,
+  'link': linkClass,
+  'ln': linkClass
+  'linked': linksClass,
+  'links': linksClass,
+  'lns': linksClass,
+  'list': listClass,
+  'ls': listClass,
+  'login': loginClass,
+  'publish': publishClass,
+  'rebuild-module-cache': rebuildModuleCacheClass,
+  'rebuild': rebuildClass,
+  'search': searchClass,
+  'star': starClass,
+  'stars': starsClass,
+  'starred': starsClass
+  'test': testClass
+  'deinstall': uninstallClass,
+  'delete': uninstallClass,
+  'erase': uninstallClass,
+  'remove': uninstallClass,
+  'rm': uninstallClass,
+  'uninstall': uninstallClass,
+  'unlink': unlinkClass,
+  'unpublish': unpublishClass,
+  'unstar': unstarClass,
+  'upgrade': upgradeClass,
+  'outdated': upgradeClass,
+  'update': upgradeClass,
+  'view': viewClass,
+  'show': viewClass,
+}
 
 parseOptions = (args=[]) ->
   options = yargs(args).wrap(Math.min(100, yargs.terminalWidth()))

--- a/src/ci.coffee
+++ b/src/ci.coffee
@@ -9,8 +9,6 @@ Command = require './command'
 
 module.exports =
 class Ci extends Command
-  @commandNames: ['ci']
-
   constructor: ->
     super()
     @atomDirectory = config.getAtomDirectory()

--- a/src/clean.coffee
+++ b/src/clean.coffee
@@ -11,8 +11,6 @@ fs = require './fs'
 
 module.exports =
 class Clean extends Command
-  @commandNames: ['clean', 'prune']
-
   constructor: ->
     super()
     @atomNpmPath = require.resolve('npm/bin/npm-cli')

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -6,8 +6,6 @@ Command = require './command'
 
 module.exports =
 class Config extends Command
-  @commandNames: ['config']
-
   constructor: ->
     super()
     atomDirectory = apm.getAtomDirectory()

--- a/src/dedupe.coffee
+++ b/src/dedupe.coffee
@@ -10,8 +10,6 @@ fs = require './fs'
 
 module.exports =
 class Dedupe extends Command
-  @commandNames: ['dedupe']
-
   constructor: ->
     super()
     @atomDirectory = config.getAtomDirectory()

--- a/src/develop.coffee
+++ b/src/develop.coffee
@@ -14,8 +14,6 @@ request = require './request'
 
 module.exports =
 class Develop extends Command
-  @commandNames: ['dev', 'develop']
-
   constructor: ->
     super()
     @atomDirectory = config.getAtomDirectory()

--- a/src/disable.coffee
+++ b/src/disable.coffee
@@ -9,8 +9,6 @@ List = require './list'
 
 module.exports =
 class Disable extends Command
-  @commandNames: ['disable']
-
   parseOptions: (argv) ->
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
     options.usage """

--- a/src/docs.coffee
+++ b/src/docs.coffee
@@ -6,8 +6,6 @@ config = require './apm'
 
 module.exports =
 class Docs extends View
-  @commandNames: ['docs', 'home', 'open']
-
   parseOptions: (argv) ->
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
     options.usage """

--- a/src/enable.coffee
+++ b/src/enable.coffee
@@ -8,8 +8,6 @@ Command = require './command'
 
 module.exports =
 class Enable extends Command
-  @commandNames: ['enable']
-
   parseOptions: (argv) ->
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
     options.usage """

--- a/src/featured.coffee
+++ b/src/featured.coffee
@@ -8,8 +8,6 @@ tree = require './tree'
 
 module.exports =
 class Featured extends Command
-  @commandNames: ['featured']
-
   parseOptions: (argv) ->
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
     options.usage """

--- a/src/init.coffee
+++ b/src/init.coffee
@@ -7,8 +7,6 @@ fs = require './fs'
 
 module.exports =
 class Init extends Command
-  @commandNames: ['init']
-
   supportedSyntaxes: ['coffeescript', 'javascript']
 
   parseOptions: (argv) ->

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -19,8 +19,6 @@ request = require './request'
 
 module.exports =
 class Install extends Command
-  @commandNames: ['install', 'i']
-
   constructor: ->
     super()
     @atomDirectory = config.getAtomDirectory()

--- a/src/link.coffee
+++ b/src/link.coffee
@@ -9,8 +9,6 @@ fs = require './fs'
 
 module.exports =
 class Link extends Command
-  @commandNames: ['link', 'ln']
-
   parseOptions: (argv) ->
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
     options.usage """

--- a/src/links.coffee
+++ b/src/links.coffee
@@ -9,8 +9,6 @@ tree = require './tree'
 
 module.exports =
 class Links extends Command
-  @commandNames: ['linked', 'links', 'lns']
-
   constructor: ->
     super()
     @devPackagesPath = path.join(config.getAtomDirectory(), 'dev', 'packages')

--- a/src/list.coffee
+++ b/src/list.coffee
@@ -12,8 +12,6 @@ tree = require './tree'
 
 module.exports =
 class List extends Command
-  @commandNames: ['list', 'ls']
-
   constructor: ->
     super()
     @userPackagesDirectory = path.join(config.getAtomDirectory(), 'packages')

--- a/src/login.coffee
+++ b/src/login.coffee
@@ -16,8 +16,6 @@ class Login extends Command
       else
         callback(null, token)
 
-  @commandNames: ['login']
-
   parseOptions: (argv) ->
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
 

--- a/src/publish.coffee
+++ b/src/publish.coffee
@@ -14,8 +14,6 @@ request = require './request'
 
 module.exports =
 class Publish extends Command
-  @commandNames: ['publish']
-
   constructor: ->
     super()
     @userConfigPath = config.getUserConfigPath()

--- a/src/rebuild-module-cache.coffee
+++ b/src/rebuild-module-cache.coffee
@@ -7,8 +7,6 @@ fs = require './fs'
 
 module.exports =
 class RebuildModuleCache extends Command
-  @commandNames: ['rebuild-module-cache']
-
   constructor: ->
     super()
     @atomPackagesDirectory = path.join(config.getAtomDirectory(), 'packages')

--- a/src/rebuild.coffee
+++ b/src/rebuild.coffee
@@ -10,8 +10,6 @@ Install = require './install'
 
 module.exports =
 class Rebuild extends Command
-  @commandNames: ['rebuild']
-
   constructor: ->
     super()
     @atomDirectory = config.getAtomDirectory()

--- a/src/search.coffee
+++ b/src/search.coffee
@@ -9,8 +9,6 @@ tree = require './tree'
 
 module.exports =
 class Search extends Command
-  @commandNames: ['search']
-
   parseOptions: (argv) ->
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
     options.usage """

--- a/src/star.coffee
+++ b/src/star.coffee
@@ -14,8 +14,6 @@ request = require './request'
 
 module.exports =
 class Star extends Command
-  @commandNames: ['star']
-
   parseOptions: (argv) ->
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
     options.usage """

--- a/src/stars.coffee
+++ b/src/stars.coffee
@@ -10,8 +10,6 @@ tree = require './tree'
 
 module.exports =
 class Stars extends Command
-  @commandNames: ['stars', 'starred']
-
   parseOptions: (argv) ->
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
     options.usage """

--- a/src/test.coffee
+++ b/src/test.coffee
@@ -8,8 +8,6 @@ fs = require './fs'
 
 module.exports =
 class Test extends Command
-  @commandNames: ['test']
-
   parseOptions: (argv) ->
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
 

--- a/src/uninstall.coffee
+++ b/src/uninstall.coffee
@@ -12,8 +12,6 @@ request = require './request'
 
 module.exports =
 class Uninstall extends Command
-  @commandNames: ['deinstall', 'delete', 'erase', 'remove', 'rm', 'uninstall']
-
   parseOptions: (argv) ->
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
     options.usage """

--- a/src/unlink.coffee
+++ b/src/unlink.coffee
@@ -9,8 +9,6 @@ fs = require './fs'
 
 module.exports =
 class Unlink extends Command
-  @commandNames: ['unlink']
-
   constructor: ->
     super()
     @devPackagesPath = path.join(config.getAtomDirectory(), 'dev', 'packages')

--- a/src/unpublish.coffee
+++ b/src/unpublish.coffee
@@ -11,8 +11,6 @@ request = require './request'
 
 module.exports =
 class Unpublish extends Command
-  @commandNames: ['unpublish']
-
   parseOptions: (argv) ->
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
 

--- a/src/unstar.coffee
+++ b/src/unstar.coffee
@@ -8,8 +8,6 @@ request = require './request'
 
 module.exports =
 class Unstar extends Command
-  @commandNames: ['unstar']
-
   parseOptions: (argv) ->
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
     options.usage """

--- a/src/upgrade.coffee
+++ b/src/upgrade.coffee
@@ -18,8 +18,6 @@ git = require './git'
 
 module.exports =
 class Upgrade extends Command
-  @commandNames: ['upgrade', 'outdated', 'update']
-
   constructor: ->
     super()
     @atomDirectory = config.getAtomDirectory()

--- a/src/view.coffee
+++ b/src/view.coffee
@@ -9,8 +9,6 @@ tree = require './tree'
 
 module.exports =
 class View extends Command
-  @commandNames: ['view', 'show']
-
   parseOptions: (argv) ->
     options = yargs(argv).wrap(Math.min(100, yargs.terminalWidth()))
     options.usage """


### PR DESCRIPTION
- The `apm --help` command is now ~30% faster
- `@commandNames` in CoffeeScript is translated to `initClass` in JavaScript, which is not a good idea.
